### PR TITLE
Upgrade k8s version to allow using correct api's. Add queue-name para…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Kubernetes pod autoscaler based on queue size in AWS SQS
 ## Usage
 Create a kubernetes deployment like this:
 ```
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: my-k8s-autoscaler
@@ -21,10 +21,10 @@ spec:
         image: sideshowbandana/k8s-sqs-autoscaler:1.0.0
         command:
           - ./k8s-sqs-autoscaler
-          - --sqs-queue-url=https://sqs.$(AWS_REGION).amazonaws.com/$(AWS_ID)/$(SQS_QUEUE) # required
+          - --sqs-queue-name=${SQS_QUEUE_NAME}
           - --kubernetes-deployment=$(KUBERNETES_DEPLOYMENT)
           - --kubernetes-namespace=$(K8S_NAMESPACE) # optional
-          - --aws-region=us-west-2  #required
+          - --aws-region=${AWS_REGION}  #required
           - --poll-period=10 # optional
           - --scale-down-cool-down=30 # optional
           - --scale-up-cool-down=10 # optional
@@ -33,10 +33,16 @@ spec:
           - --max-pods=30 # optional
           - --min-pods=1 # optional
         env:
+          - name: AWS_REGION
+            value: us-east-1
           - name: K8S_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: KUBERNETES_DEPLOYMENT
+            value: my-k8s-app
+          - name: SQS_QUEUE_NAME
+            value: sqs-queue-name
         resources:
           requests:
             memory: "64Mi"

--- a/k8s-sqs-autoscaler
+++ b/k8s-sqs-autoscaler
@@ -10,6 +10,9 @@ if __name__ == '__main__':
     parser.add_option("--sqs-queue-url",
                       dest="sqs_queue_url",
                       help="SQS Queue URL")
+    parser.add_option("--sqs-queue-name",
+                      dest="sqs_queue_name",
+                      help="SQS Queue Name")
     parser.add_option("--kubernetes-deployment",
                       dest="kubernetes_deployment",
                       help="")
@@ -57,8 +60,8 @@ if __name__ == '__main__':
 
     (options, args) = parser.parse_args()
 
-    if not options.sqs_queue_url:
-        parser.error('SQS_QUEUE_URL not given')
+    if not (options.sqs_queue_url or options.sqs_queue_name):
+        parser.error('SQS_QUEUE_URL / SQS_QUEUE_NAME not given')
     if not options.kubernetes_deployment:
         parser.error('KUBERNETES_DEPLOYMENT not given')
     if not options.aws_region:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3==1.5.12
 pytest==3.3.2
 flake8==3.4.1
-kubernetes==6.0.0
+kubernetes==10.0.0

--- a/sqs/sqs.py
+++ b/sqs/sqs.py
@@ -4,18 +4,25 @@ from time import sleep, time
 from logs.log import logger
 from kubernetes import client, config
 
+
 class SQSPoller:
 
     options = None
     sqs_client = None
-    extensions_v1_beta1 = None
+    apps_v1 = None
     last_message_count = None
 
     def __init__(self, options):
         self.options = options
-        self.sqs_client = boto3.client('sqs')
+        self.sqs_client = boto3.client('sqs', region_name=options.aws_region)
         config.load_incluster_config()
-        self.extensions_v1_beta1 = client.ExtensionsV1beta1Api()
+
+        if not self.options.sqs_queue_url:
+            # derive the URL from the queue name
+            self.options.sqs_queue_url = self.sqs_client.get_queue_url(
+                QueueName=self.options.sqs_queue_name)['QueueUrl']
+
+        self.apps_v1 = client.AppsV1Api()
         self.last_scale_up_time = time()
         self.last_scale_down_time = time()
 
@@ -26,11 +33,10 @@ class SQSPoller:
         )
         return int(response['Attributes']['ApproximateNumberOfMessages'])
 
-
     def poll(self):
         message_count = self.message_count()
         t = time()
-        if  message_count >= self.options.scale_up_messages:
+        if message_count >= self.options.scale_up_messages:
             if t - self.last_scale_up_time > self.options.scale_up_cool_down:
                 self.scale_up()
                 self.last_scale_up_time = t
@@ -69,13 +75,15 @@ class SQSPoller:
             logger.info("Min pods reached")
 
     def deployment(self):
-        logger.debug("loading deployment: {} from namespace: {}".format(self.options.kubernetes_deployment, self.options.kubernetes_namespace))
-        deployments = self.extensions_v1_beta1.list_namespaced_deployment(self.options.kubernetes_namespace, label_selector="app={}".format(self.options.kubernetes_deployment))
+        logger.debug("loading deployment: {} from namespace: {}".format(
+            self.options.kubernetes_deployment, self.options.kubernetes_namespace))
+        deployments = self.apps_v1.list_namespaced_deployment(
+            self.options.kubernetes_namespace, label_selector="app={}".format(self.options.kubernetes_deployment))
         return deployments.items[0]
 
     def update_deployment(self, deployment):
         # Update the deployment
-        api_response = self.extensions_v1_beta1.patch_namespaced_deployment(
+        api_response = self.apps_v1.patch_namespaced_deployment(
             name=self.options.kubernetes_deployment,
             namespace=self.options.kubernetes_namespace,
             body=deployment)
@@ -83,9 +91,11 @@ class SQSPoller:
 
     def run(self):
         options = self.options
-        logger.debug("Starting poll for {} every {}s".format(options.sqs_queue_url, options.poll_period))
+        logger.debug("Starting poll for {} every {}s".format(
+            options.sqs_queue_url, options.poll_period))
         while True:
             self.poll()
+
 
 def run(options):
     """


### PR DESCRIPTION
This applies a number of pr's that haven't been applied upstream. The main features are:
  - upgrade deployment to apps/v1
  - upgrade k8s version to support above
  - addition of queue-name parameter so you don't need to assemble the full queue url yourself